### PR TITLE
Add YAML file extensions to supported types

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -18,7 +18,7 @@ The FCEDitor is accessible at http://fceditor.dps.uibk.ac.at:8180/.
 * Node v12
 
 **Install dependencies**  
-1. Add AFCL API to local maven repo: `mvn install:install-file -Dfile=./src/main/resources/afclAPI.jar -DgroupId=com.dps.afcl -DartifactId=afcl-api -Dversion=1.0 -Dpackaging=JAR`
+1. Add AFCL API to local maven repo: `mvn install:install-file -Dfile=./src/main/resources/afclAPI.jar -DgroupId=com.dps.afcl -DartifactId=afcl-api -Dversion=1.0 -Dpackaging=jar`
 2. Install dependencies: `mvn install`  
 
 If using an IDE, reimport - e.g if using IntelliJ:  

--- a/src/main/webapp/src/js/components/Editor.js
+++ b/src/main/webapp/src/js/components/Editor.js
@@ -85,6 +85,8 @@ class Editor extends React.Component {
         'text/yaml'
     ];
 
+    YAML_FILE_EXTENSIONS = ['.yaml', '.yml'];
+
     constructor(props) {
         super(props);
 
@@ -608,7 +610,7 @@ class Editor extends React.Component {
 
         FileDialog({
             multiple: false,
-            accept: allMimeTypes
+            accept: allMimeTypes.concat(this.YAML_FILE_EXTENSIONS)
         }).then(async files => {
             let file = files[0];
 


### PR DESCRIPTION
## Changes

* **Add YAML file extensions to supported types**
Allows loading of workflow files ending with `.yaml` or `.yml` in case the MIME type isn't recognized correctly.
* **Correct `mvn install:install-file` command in Readme.md**
Replace `-Dpackaging=JAR` with `-Dpackaging=jar` to avoid _"Could not find artifact"_ issues on case-sensitive systems.